### PR TITLE
fixed background colour inconsistency

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -51,7 +51,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <div className="min-h-screen bg-slate-50 dark:bg-black">
+        <div className="min-h-screen bg-slate-50 dark:bg-background">
           <ThemeProvider>
             <AuthProvider>
               <Navbar />


### PR DESCRIPTION
## Changes Made

Brief description of what you changed using bullet points

- Changed layout background colour to correct colour

## Additional Notes/Screenshots/Videos 
- There was a inconsistency with the background colour and the footer.

before:
<img width="854" height="160" alt="Screenshot 2025-10-24 at 12 33 06 AM" src="https://github.com/user-attachments/assets/6fc5e621-7486-4540-8dcc-1da600388c49" />

after:
<img width="860" height="166" alt="Screenshot 2025-10-24 at 12 33 49 AM" src="https://github.com/user-attachments/assets/7dd5e698-1e37-4a27-b701-6a16add49c4b" />